### PR TITLE
chore: Change site index to Articles page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  root to: 'articles#index'
   resources :articles
 end


### PR DESCRIPTION
Before this commit, the index page was showing the Rails starter page. 
This change makes sure that the root index is now the Articles page.